### PR TITLE
Changed theme to have transparent background as default

### DIFF
--- a/lib/motion-plot/chart/pie_plot.rb
+++ b/lib/motion-plot/chart/pie_plot.rb
@@ -113,14 +113,14 @@ module MotionPlot
       plot.addAnimation(radial_animation, forKey:"pieRadius")
 
 
-      angle_animation                     = CABasicAnimation.animationWithKeyPath 'angle'
-      angle_animation.fromValue           = 0.0
+      angle_animation                     = CABasicAnimation.animationWithKeyPath 'endAngle'
+      angle_animation.fromValue           = -(Math::PI * 7/4)
       angle_animation.toValue             = Math::PI/4
       angle_animation.duration            = 1.0
       angle_animation.removedOnCompletion = false
       angle_animation.fillMode            = KCAFillModeForwards
 
-      plot.addAnimation(angle_animation, forKey:"angle") 
+      plot.addAnimation(angle_animation, forKey:"endAngle")
 
       CATransaction.commit
     end

--- a/lib/motion-plot/theme/theme.rb
+++ b/lib/motion-plot/theme/theme.rb
@@ -10,7 +10,7 @@ module MotionPlot
 
     class << self
       def method_missing(m, *args, &block)
-        method_name = m == :default ? :plain_white : m
+        return if m == :default
 
         raise unless(DEFAULTS.keys.include?(method_name))       
 


### PR DESCRIPTION
I needed a chart with transparent background. This change adds transparent background functionality by changing the default from plain_white to transparent.
